### PR TITLE
ホーム画面にヘッダーを追加

### DIFF
--- a/frontend/app/components/elements/header/header.tsx
+++ b/frontend/app/components/elements/header/header.tsx
@@ -1,9 +1,16 @@
 "use client";
 
+import CircleNotificationsIcon from "@mui/icons-material/CircleNotifications";
+
 import AppBar from "@mui/material/AppBar";
 import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import styled from "@mui/material/styles/styled";
+
+// 通知アイコンのスタイル
+const NotifyIcon = styled(CircleNotificationsIcon)({
+  fontSize: 35,
+});
 
 // ヘッダータイトルのスタイル
 const HeaderTitle = styled(Typography)({
@@ -18,6 +25,7 @@ export const Header = () => {
     <>
       <AppBar component="nav">
         <Toolbar>
+          <NotifyIcon />
           <HeaderTitle variant="h5">Rakuten Price Notify</HeaderTitle>
         </Toolbar>
       </AppBar>

--- a/frontend/app/components/elements/header/header.tsx
+++ b/frontend/app/components/elements/header/header.tsx
@@ -1,0 +1,15 @@
+import AppBar from "@mui/material/AppBar";
+import Toolbar from "@mui/material/Toolbar";
+import Typography from "@mui/material/Typography";
+
+export const Header = () => {
+  return (
+    <>
+      <AppBar component="nav">
+        <Toolbar>
+          <Typography variant="h5">楽天価格通知アプリ</Typography>
+        </Toolbar>
+      </AppBar>
+    </>
+  );
+};

--- a/frontend/app/components/elements/header/header.tsx
+++ b/frontend/app/components/elements/header/header.tsx
@@ -3,6 +3,7 @@
 import CircleNotificationsIcon from "@mui/icons-material/CircleNotifications";
 
 import AppBar from "@mui/material/AppBar";
+import Box from "@mui/material/Box";
 import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import styled from "@mui/material/styles/styled";
@@ -20,13 +21,23 @@ const HeaderTitle = styled(Typography)({
   letterSpacing: ".15rem",
 });
 
+// ヘッダー内の要素を中央揃え
+const CenterBox = styled(Box)({
+  flexGrow: 1,
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+});
+
 export const Header = () => {
   return (
     <>
       <AppBar component="nav">
         <Toolbar>
-          <NotifyIcon />
-          <HeaderTitle variant="h5">Rakuten Price Notify</HeaderTitle>
+          <CenterBox>
+            <NotifyIcon />
+            <HeaderTitle variant="h5">Rakuten Price Notify</HeaderTitle>
+          </CenterBox>
         </Toolbar>
       </AppBar>
     </>

--- a/frontend/app/components/elements/header/header.tsx
+++ b/frontend/app/components/elements/header/header.tsx
@@ -1,13 +1,24 @@
+"use client";
+
 import AppBar from "@mui/material/AppBar";
 import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
+import styled from "@mui/material/styles/styled";
+
+// ヘッダータイトルのスタイル
+const HeaderTitle = styled(Typography)({
+  fontWeight: "bold",
+  fontFamily: "monospace",
+  marginLeft: ".5rem",
+  letterSpacing: ".15rem",
+});
 
 export const Header = () => {
   return (
     <>
       <AppBar component="nav">
         <Toolbar>
-          <Typography variant="h5">楽天価格通知アプリ</Typography>
+          <HeaderTitle variant="h5">Rakuten Price Notify</HeaderTitle>
         </Toolbar>
       </AppBar>
     </>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,3 +1,9 @@
+import { Header } from "./components/elements/header/header";
+
 export default function Home() {
-  return;
+  return (
+    <>
+      <Header />
+    </>
+  );
 }


### PR DESCRIPTION
- MUIの`AppBar`を利用してHeaderコンポーネントを作成
https://mui.com/material-ui/react-app-bar/
- ヘッダータイトルは`Rakuten Price Notify`にしました
- ヘッダーに通知アイコンを表示
- ヘッダー内の要素（タイトル、通知アイコン）を中央揃えで表示