### PR TITLE
商品一覧を表示

### DIFF
--- a/frontend/app/components/elements/ItemsCard/ItemsCard.tsx
+++ b/frontend/app/components/elements/ItemsCard/ItemsCard.tsx
@@ -1,3 +1,8 @@
+import Link from "next/link";
+
+import Card from "@mui/material/Card";
+import CardMedia from "@mui/material/CardMedia";
+
 import { Title } from "../Title/Title";
 import { useFetchItemsData } from "./ItemsCard.hooks";
 
@@ -10,6 +15,18 @@ export const ItemsCard = async () => {
       <div style={{ marginTop: "2%", marginBottom: "1%" }}>
         <Title />
       </div>
+      {itemsData.map((data) => (
+        <Card key={data.genreId}>
+          <Link href={data.itemUrl} target="_blank">
+            <CardMedia
+              component="img"
+              height="250"
+              image={data.imageUrl}
+              style={{ objectFit: "contain" }}
+            />
+          </Link>
+        </Card>
+      ))}
     </>
   );
 };

--- a/frontend/app/components/elements/ItemsCard/ItemsCard.tsx
+++ b/frontend/app/components/elements/ItemsCard/ItemsCard.tsx
@@ -19,6 +19,18 @@ const itemNameStyle = {
   height: 60,
 };
 
+/**
+ * 商品価格を「¥#,###」のフォーマットに変換する
+ * @param price {number} - 商品価格
+ * @requires {string} フォーマット変換後の商品価格
+ */
+function formatCurrency(price: number): string {
+  return new Intl.NumberFormat("ja-JP", {
+    style: "currency",
+    currency: "JPY",
+  }).format(price);
+}
+
 export const ItemsCard = async () => {
   const { fetchItemsData } = useFetchItemsData();
   const itemsData = await fetchItemsData();
@@ -45,6 +57,9 @@ export const ItemsCard = async () => {
               sx={itemNameStyle}
             >
               {data.itemName}
+            </Typography>
+            <Typography variant="body1" color="text.secondary">
+              {formatCurrency(data.itemPrice)}
             </Typography>
           </CardContent>
         </Card>

--- a/frontend/app/components/elements/ItemsCard/ItemsCard.tsx
+++ b/frontend/app/components/elements/ItemsCard/ItemsCard.tsx
@@ -1,10 +1,15 @@
+import { Title } from "../Title/Title";
 import { useFetchItemsData } from "./ItemsCard.hooks";
 
 export const ItemsCard = async () => {
   const { fetchItemsData } = useFetchItemsData();
   const itemsData = await fetchItemsData();
 
-  console.log(itemsData);
-
-  return <></>;
+  return (
+    <>
+      <div style={{ marginTop: "2%", marginBottom: "1%" }}>
+        <Title />
+      </div>
+    </>
+  );
 };

--- a/frontend/app/components/elements/ItemsCard/ItemsCard.tsx
+++ b/frontend/app/components/elements/ItemsCard/ItemsCard.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import CardMedia from "@mui/material/CardMedia";
+import Container from "@mui/material/Container";
+import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
 
 import { Title } from "../Title/Title";
@@ -37,33 +39,39 @@ export const ItemsCard = async () => {
 
   return (
     <>
-      <div style={{ marginTop: "2%", marginBottom: "1%" }}>
-        <Title />
-      </div>
-      {itemsData.map((data) => (
-        <Card key={data.genreId}>
-          <Link href={data.itemUrl} target="_blank">
-            <CardMedia
-              component="img"
-              height="250"
-              image={data.imageUrl}
-              style={{ objectFit: "contain" }}
-            />
-          </Link>
-          <CardContent>
-            <Typography
-              variant="body2"
-              title={data.itemName}
-              sx={itemNameStyle}
-            >
-              {data.itemName}
-            </Typography>
-            <Typography variant="body1" color="text.secondary">
-              {formatCurrency(data.itemPrice)}
-            </Typography>
-          </CardContent>
-        </Card>
-      ))}
+      <Container maxWidth="xl">
+        <div style={{ marginTop: "2%", marginBottom: "1%" }}>
+          <Title />
+        </div>
+        <Grid container rowSpacing={2} columnSpacing={2}>
+          {itemsData.map((data) => (
+            <Grid key={data.genreId} item xs={12} sm={6} md={3} lg={2}>
+              <Card key={data.genreId}>
+                <Link href={data.itemUrl} target="_blank">
+                  <CardMedia
+                    component="img"
+                    height="250"
+                    image={data.imageUrl}
+                    style={{ objectFit: "contain" }}
+                  />
+                </Link>
+                <CardContent>
+                  <Typography
+                    variant="body2"
+                    title={data.itemName}
+                    sx={itemNameStyle}
+                  >
+                    {data.itemName}
+                  </Typography>
+                  <Typography variant="body1" color="text.secondary">
+                    {formatCurrency(data.itemPrice)}
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      </Container>
     </>
   );
 };

--- a/frontend/app/components/elements/ItemsCard/ItemsCard.tsx
+++ b/frontend/app/components/elements/ItemsCard/ItemsCard.tsx
@@ -1,10 +1,23 @@
 import Link from "next/link";
 
 import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
 import CardMedia from "@mui/material/CardMedia";
+import Typography from "@mui/material/Typography";
 
 import { Title } from "../Title/Title";
 import { useFetchItemsData } from "./ItemsCard.hooks";
+
+/* 商品名のスタイル */
+// 商品名の表示が折り返しで3行を超えた場合は3点リーダー（…）で省略して表示する
+const itemNameStyle = {
+  display: "-webkit-box",
+  WebkitBoxOrient: "vertical",
+  WebkitLineClamp: 3,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  height: 60,
+};
 
 export const ItemsCard = async () => {
   const { fetchItemsData } = useFetchItemsData();
@@ -25,6 +38,15 @@ export const ItemsCard = async () => {
               style={{ objectFit: "contain" }}
             />
           </Link>
+          <CardContent>
+            <Typography
+              variant="body2"
+              title={data.itemName}
+              sx={itemNameStyle}
+            >
+              {data.itemName}
+            </Typography>
+          </CardContent>
         </Card>
       ))}
     </>

--- a/frontend/app/components/elements/Title/Title.tsx
+++ b/frontend/app/components/elements/Title/Title.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Divider, IconButton, Tooltip, Typography } from "@mui/material";
+import InfoIcon from "@mui/icons-material/Info";
+
+export const Title = () => {
+  return (
+    <>
+      <div style={{ display: "flex" }}>
+        <Typography variant="h5">商品一覧</Typography>
+        <Tooltip title="一覧に表示されている商品の価格がセールなどで安くなったらLINE通知が届きます。">
+          <IconButton>
+            <InfoIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      </div>
+      <Divider />
+    </>
+  );
+};

--- a/frontend/app/components/elements/Title/Title.tsx
+++ b/frontend/app/components/elements/Title/Title.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Divider, IconButton, Tooltip, Typography } from "@mui/material";
 import InfoIcon from "@mui/icons-material/Info";
 

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -13,8 +13,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang='en'>
-      <body className={inter.className}>{children}</body>
+    <html lang="en">
+      <body style={{ background: "#f5f5f5" }} className={inter.className}>
+        {children}
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
- ローカル環境のモックapiから商品データを取得して、商品一覧を表示するところまで実装
- 商品画像
  - クリックしたら別タブで楽天の商品ページを開く
- 商品名
  - 商品名の表示が折り返しで3行を超えたら、3点リーダーで省略して表示
  - マウスポインタを当てると、商品名のポップアップを表示
- 商品価格
  - 「¥#,###」のフォーマットで表示