### PR TITLE
Items（楽天商品データ格納テーブル）の設定を変更

### DIFF
--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -73,12 +73,12 @@ Resources:
     Properties:
       TableName: !Ref ItemsTableName
       AttributeDefinitions:
-        - AttributeName: genreId
+        - AttributeName: itemCode
           AttributeType: S
         - AttributeName: createdAt
           AttributeType: S
       KeySchema:
-        - AttributeName: genreId
+        - AttributeName: itemCode
           KeyType: HASH
         - AttributeName: createdAt
           KeyType: RANGE

--- a/frontend/app/components/elements/ItemsCard/ItemsCard.tsx
+++ b/frontend/app/components/elements/ItemsCard/ItemsCard.tsx
@@ -45,8 +45,8 @@ export const ItemsCard = async () => {
         </div>
         <Grid container rowSpacing={2} columnSpacing={2}>
           {itemsData.map((data) => (
-            <Grid key={data.genreId} item xs={12} sm={6} md={3} lg={2}>
-              <Card key={data.genreId}>
+            <Grid key={data.itemCode} item xs={12} sm={6} md={3} lg={2}>
+              <Card key={data.itemCode}>
                 <Link href={data.itemUrl} target="_blank">
                   <CardMedia
                     component="img"

--- a/frontend/app/type/types.ts
+++ b/frontend/app/type/types.ts
@@ -3,7 +3,7 @@ export type itemsData = { items: itemData[] }
 
 // 楽天の商品データの型情報
 export type itemData = {
-  genreId: string,
+  itemCode: string,
   itemName: string,
   itemPrice: number,
   itemUrl: string,


### PR DESCRIPTION
- 楽天APIの商品データを確認したら`genreId`は一意でないことが判明したので、パーティションキーを`itemCode`に変更
- 上記の変更に伴い、フロントエンドのコードで`genreId`を指定していた箇所を`itemCode`に修正しました