### PR TITLE
DynamoDBに楽天の商品データを登録

### DIFF
--- a/backend/item/Dockerfile
+++ b/backend/item/Dockerfile
@@ -4,6 +4,7 @@ COPY item/requirements.txt ${LAMBDA_TASK_ROOT}/requirements.txt
 
 COPY item/main.py ${LAMBDA_TASK_ROOT}/main.py
 COPY item/fetch_item_handler.py ${LAMBDA_TASK_ROOT}/fetch_item_handler.py
+COPY item/put_item_handler.py ${LAMBDA_TASK_ROOT}/put_item_handler.py
 COPY item/delete_item_handler.py ${LAMBDA_TASK_ROOT}/delete_item_handler.py
 
 COPY db/table.py ${LAMBDA_TASK_ROOT}/db/table.py

--- a/backend/item/main.py
+++ b/backend/item/main.py
@@ -2,12 +2,14 @@ import json
 import logging
 
 from fetch_item_handler import fetch_item_handler
+from put_item_handler import put_item_handler
 from delete_item_handler import delete_item_handler
 
 
 def handler(event, context):
     handler_mapping = {
         "/api/fetch_item": fetch_item_handler,
+        "/api/put_item": put_item_handler,
         "/api/delete_item": delete_item_handler,
     }
     try:

--- a/backend/item/put_item_handler.py
+++ b/backend/item/put_item_handler.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from db.table import get_table
+
+
+def put_item_handler(payload: dict):
+    """楽天の商品データを登録"""
+    get_table("Items").put_item(
+        Item={
+            "createdAt": str(datetime.now()),
+            "itemCode": payload["itemCode"],
+            "itemName": payload["itemName"],
+            "itemPrice": payload["itemPrice"],
+            "itemUrl": payload["itemUrl"],
+            "mediumImageUrls": [
+                {
+                    "imageUrl": payload["imageUrl"],
+                }
+            ],
+        }
+    )
+
+    return {"isSuccess": True}

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -49,6 +49,12 @@ Resources:
             # このパスのイベントを受け取ったときにItemActionラムダを実行
             Path: /api/fetch_item
             Method: get
+        ItemActionCreate:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MyApi
+            Path: /api/put_item
+            Method: post
         ItemActionDelete:
           Type: Api
           Properties:
@@ -112,6 +118,9 @@ Outputs:
   FetchItemApi:
     Description: "API Gateway endpoint URL for Prod stage for ItemAction function"
     Value: !Sub "https://${MyApi}.execute-api.${AWS::Region}.amazonaws.com/${StageName}/api/fetch_item/"
+  PutItemApi:
+    Description: "API Gateway endpoint URL for Prod stage for ItemAction function"
+    Value: !Sub "https://${MyApi}.execute-api.${AWS::Region}.amazonaws.com/${StageName}/api/put_item/"
   DeleteItemApi:
     Description: "API Gateway endpoint URL for Prod stage for ItemAction function"
     Value: !Sub "https://${MyApi}.execute-api.${AWS::Region}.amazonaws.com/${StageName}/api/delete_item/"

--- a/frontend/app/components/container/AddButton/AddButton.tsx
+++ b/frontend/app/components/container/AddButton/AddButton.tsx
@@ -1,0 +1,18 @@
+import AddIcon from "@mui/icons-material/Add";
+import Fab from "@mui/material/Fab";
+
+const buttonStyle = {
+  position: "fixed",
+  bottom: 24,
+  right: 24,
+};
+
+export const AddButton = () => {
+  return (
+    <>
+      <Fab color="primary" sx={buttonStyle}>
+        <AddIcon />
+      </Fab>
+    </>
+  );
+};

--- a/frontend/app/components/container/AddButton/AddButton.tsx
+++ b/frontend/app/components/container/AddButton/AddButton.tsx
@@ -1,5 +1,8 @@
+"use client";
 import AddIcon from "@mui/icons-material/Add";
 import Fab from "@mui/material/Fab";
+import { AddModal } from "../AddModal/AddModal";
+import { useState } from "react";
 
 const buttonStyle = {
   position: "fixed",
@@ -8,11 +11,16 @@ const buttonStyle = {
 };
 
 export const AddButton = () => {
+  const [open, setOpen] = useState(false);
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
   return (
     <>
-      <Fab color="primary" sx={buttonStyle}>
+      <Fab color="primary" sx={buttonStyle} onClick={handleOpen}>
         <AddIcon />
       </Fab>
+      <AddModal open={open} handleClose={handleClose} />
     </>
   );
 };

--- a/frontend/app/components/container/AddModal/AddModal.hooks.ts
+++ b/frontend/app/components/container/AddModal/AddModal.hooks.ts
@@ -1,0 +1,25 @@
+import { itemData } from "@/app/type/types";
+
+interface RakutenItems {
+  Items: { Item: itemData }[];
+}
+
+// 楽天のAPIから商品データを取得するhooks
+export const useFetchItemsData = () => {
+  const fetchItemsData = async (searchText: string): Promise<itemData[]> => {
+    const API_KEY = process.env.NEXT_PUBLIC_RAKUTEN_API_KEY;
+    const API_URL = process.env.NEXT_PUBLIC_RAKUTEN_API_URL;
+    const params = `applicationId=${API_KEY}&keyword=${searchText}`;
+
+    const response = await fetch(API_URL + params);
+
+    if (response.ok) {
+      const itemsData: RakutenItems = await response.json();
+      return itemsData.Items.map((item) => item.Item);
+    } else {
+      return [];
+    }
+  };
+
+  return { fetchItemsData };
+};

--- a/frontend/app/components/container/AddModal/AddModal.tsx
+++ b/frontend/app/components/container/AddModal/AddModal.tsx
@@ -7,6 +7,7 @@ import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import Modal from "@mui/material/Modal";
 import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
 
 const boxStyle = {
   position: "absolute",
@@ -42,6 +43,9 @@ export const AddModal = (props: Props) => {
     <>
       <Modal open={props.open} onClose={props.handleClose}>
         <Box sx={boxStyle}>
+          <Typography variant="h5" fontWeight={550}>
+            ほしいものリストに追加
+          </Typography>
           <form onSubmit={onSearch}>
             <TextField
               placeholder="ほしいものリストに追加する商品を検索"

--- a/frontend/app/components/container/AddModal/AddModal.tsx
+++ b/frontend/app/components/container/AddModal/AddModal.tsx
@@ -73,7 +73,11 @@ export const AddModal = (props: Props) => {
           </form>
           <Grid container spacing={2}>
             {itemsData.map((data, index) => (
-              <SearchResults key={index} data={data} />
+              <SearchResults
+                key={index}
+                data={data}
+                handleClose={props.handleClose}
+              />
             ))}
           </Grid>
         </Box>

--- a/frontend/app/components/container/AddModal/AddModal.tsx
+++ b/frontend/app/components/container/AddModal/AddModal.tsx
@@ -5,11 +5,13 @@ import { useFetchItemsData } from "./AddModal.hooks";
 import { SearchResults } from "../SearchResults/SearchResults";
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
+import IconButton from "@mui/material/IconButton";
 import InputAdornment from "@mui/material/InputAdornment";
 import Modal from "@mui/material/Modal";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import SearchIcon from "@mui/icons-material/Search";
+import CloseIcon from "@mui/icons-material/Close";
 
 const boxStyle = {
   position: "absolute",
@@ -52,6 +54,9 @@ export const AddModal = (props: Props) => {
     <>
       <Modal open={props.open} onClose={props.handleClose}>
         <Box sx={boxStyle}>
+          <IconButton onClick={props.handleClose} sx={{ float: "right" }}>
+            <CloseIcon />
+          </IconButton>
           <Typography variant="h5" fontWeight={550}>
             ほしいものリストに追加
           </Typography>

--- a/frontend/app/components/container/AddModal/AddModal.tsx
+++ b/frontend/app/components/container/AddModal/AddModal.tsx
@@ -16,7 +16,7 @@ const boxStyle = {
   top: "50%",
   left: "50%",
   transform: "translate(-50%, -50%)",
-  bgcolor: "#f5f5f5",
+  bgcolor: "white",
   boxShadow: 24,
   p: 3,
   overflowY: "auto",
@@ -50,9 +50,10 @@ export const AddModal = (props: Props) => {
           </Typography>
           <form onSubmit={onSearch}>
             <TextField
-              placeholder="ほしいものリストに追加する商品を検索"
+              placeholder="商品名を入力（例：スマホ）"
               fullWidth
               defaultValue=""
+              sx={{ my: 1 }}
               InputProps={{
                 startAdornment: (
                   <InputAdornment position="start">

--- a/frontend/app/components/container/AddModal/AddModal.tsx
+++ b/frontend/app/components/container/AddModal/AddModal.tsx
@@ -2,7 +2,9 @@
 import { itemData } from "@/app/type/types";
 import { FormEvent, useState } from "react";
 import { useFetchItemsData } from "./AddModal.hooks";
+import { SearchResults } from "../SearchResults/SearchResults";
 import Box from "@mui/material/Box";
+import Grid from "@mui/material/Grid";
 import Modal from "@mui/material/Modal";
 import TextField from "@mui/material/TextField";
 
@@ -14,6 +16,8 @@ const boxStyle = {
   bgcolor: "#f5f5f5",
   boxShadow: 24,
   p: 3,
+  overflowY: "auto",
+  height: "80vh",
   width: { xs: "90%", sm: "80%", xl: "60%" },
 };
 
@@ -24,13 +28,14 @@ interface Props {
 
 export const AddModal = (props: Props) => {
   const [searchText, setSearchText] = useState("");
+  const [itemsData, setItemsData] = useState<itemData[]>([]);
   const { fetchItemsData } = useFetchItemsData();
 
   const onSearch = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const result: itemData[] = await fetchItemsData(searchText);
 
-    console.log(result);
+    setItemsData(result);
   };
 
   return (
@@ -45,6 +50,11 @@ export const AddModal = (props: Props) => {
               onChange={(e) => setSearchText(e.target.value)}
             />
           </form>
+          <Grid container spacing={2}>
+            {itemsData.map((data, index) => (
+              <SearchResults key={index} data={data} />
+            ))}
+          </Grid>
         </Box>
       </Modal>
     </>

--- a/frontend/app/components/container/AddModal/AddModal.tsx
+++ b/frontend/app/components/container/AddModal/AddModal.tsx
@@ -1,0 +1,37 @@
+import Box from "@mui/material/Box";
+import Modal from "@mui/material/Modal";
+import TextField from "@mui/material/TextField";
+
+const boxStyle = {
+  position: "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  bgcolor: "#f5f5f5",
+  boxShadow: 24,
+  p: 3,
+  width: { xs: "90%", sm: "80%", xl: "60%" },
+};
+
+interface Props {
+  open: boolean;
+  handleClose(): void;
+}
+
+export const AddModal = (props: Props) => {
+  return (
+    <>
+      <Modal open={props.open} onClose={props.handleClose}>
+        <Box sx={boxStyle}>
+          <form>
+            <TextField
+              placeholder="ほしいものリストに追加する商品を検索"
+              fullWidth
+              defaultValue=""
+            />
+          </form>
+        </Box>
+      </Modal>
+    </>
+  );
+};

--- a/frontend/app/components/container/AddModal/AddModal.tsx
+++ b/frontend/app/components/container/AddModal/AddModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { itemData } from "@/app/type/types";
-import { FormEvent, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import { useFetchItemsData } from "./AddModal.hooks";
 import { SearchResults } from "../SearchResults/SearchResults";
 import Box from "@mui/material/Box";
@@ -40,6 +40,13 @@ export const AddModal = (props: Props) => {
 
     setItemsData(result);
   };
+
+  useEffect(() => {
+    if (!props.open) {
+      setSearchText("");
+      setItemsData([]);
+    }
+  }, [props.open]);
 
   return (
     <>

--- a/frontend/app/components/container/AddModal/AddModal.tsx
+++ b/frontend/app/components/container/AddModal/AddModal.tsx
@@ -1,3 +1,7 @@
+"use client";
+import { itemData } from "@/app/type/types";
+import { FormEvent, useState } from "react";
+import { useFetchItemsData } from "./AddModal.hooks";
 import Box from "@mui/material/Box";
 import Modal from "@mui/material/Modal";
 import TextField from "@mui/material/TextField";
@@ -19,15 +23,26 @@ interface Props {
 }
 
 export const AddModal = (props: Props) => {
+  const [searchText, setSearchText] = useState("");
+  const { fetchItemsData } = useFetchItemsData();
+
+  const onSearch = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const result: itemData[] = await fetchItemsData(searchText);
+
+    console.log(result);
+  };
+
   return (
     <>
       <Modal open={props.open} onClose={props.handleClose}>
         <Box sx={boxStyle}>
-          <form>
+          <form onSubmit={onSearch}>
             <TextField
               placeholder="ほしいものリストに追加する商品を検索"
               fullWidth
               defaultValue=""
+              onChange={(e) => setSearchText(e.target.value)}
             />
           </form>
         </Box>

--- a/frontend/app/components/container/AddModal/AddModal.tsx
+++ b/frontend/app/components/container/AddModal/AddModal.tsx
@@ -20,10 +20,19 @@ const boxStyle = {
   transform: "translate(-50%, -50%)",
   bgcolor: "white",
   boxShadow: 24,
-  p: 3,
+  px: 3,
+  pb: 3,
   overflowY: "auto",
   height: "80vh",
   width: { xs: "90%", sm: "80%", xl: "60%" },
+};
+
+const headerStyle = {
+  position: "sticky",
+  top: 0,
+  backgroundColor: "white",
+  zIndex: 1,
+  pt: 3,
 };
 
 interface Props {
@@ -54,28 +63,30 @@ export const AddModal = (props: Props) => {
     <>
       <Modal open={props.open} onClose={props.handleClose}>
         <Box sx={boxStyle}>
-          <IconButton onClick={props.handleClose} sx={{ float: "right" }}>
-            <CloseIcon />
-          </IconButton>
-          <Typography variant="h5" fontWeight={550}>
-            ほしいものリストに追加
-          </Typography>
-          <form onSubmit={onSearch}>
-            <TextField
-              placeholder="商品名を入力（例：スマホ）"
-              fullWidth
-              defaultValue=""
-              sx={{ my: 1 }}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <SearchIcon />
-                  </InputAdornment>
-                ),
-              }}
-              onChange={(e) => setSearchText(e.target.value)}
-            />
-          </form>
+          <Box sx={headerStyle}>
+            <IconButton onClick={props.handleClose} sx={{ float: "right" }}>
+              <CloseIcon />
+            </IconButton>
+            <Typography variant="h5" fontWeight={550}>
+              ほしいものリストに追加
+            </Typography>
+            <form onSubmit={onSearch}>
+              <TextField
+                placeholder="商品名を入力（例：スマホ）"
+                fullWidth
+                defaultValue=""
+                sx={{ my: 1 }}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <SearchIcon />
+                    </InputAdornment>
+                  ),
+                }}
+                onChange={(e) => setSearchText(e.target.value)}
+              />
+            </form>
+          </Box>
           <Grid container spacing={2}>
             {itemsData.map((data, index) => (
               <SearchResults

--- a/frontend/app/components/container/AddModal/AddModal.tsx
+++ b/frontend/app/components/container/AddModal/AddModal.tsx
@@ -5,9 +5,11 @@ import { useFetchItemsData } from "./AddModal.hooks";
 import { SearchResults } from "../SearchResults/SearchResults";
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
+import InputAdornment from "@mui/material/InputAdornment";
 import Modal from "@mui/material/Modal";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
+import SearchIcon from "@mui/icons-material/Search";
 
 const boxStyle = {
   position: "absolute",
@@ -51,6 +53,13 @@ export const AddModal = (props: Props) => {
               placeholder="ほしいものリストに追加する商品を検索"
               fullWidth
               defaultValue=""
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon />
+                  </InputAdornment>
+                ),
+              }}
               onChange={(e) => setSearchText(e.target.value)}
             />
           </form>

--- a/frontend/app/components/container/DeleteConfirmDialog/DeleteConfirmDialog.tsx
+++ b/frontend/app/components/container/DeleteConfirmDialog/DeleteConfirmDialog.tsx
@@ -41,7 +41,7 @@ export const DeleteConfirmDialog = (props: Props) => {
             component="img"
             sx={{ width: 120, height: "auto" }}
             alt={props.data.itemName}
-            src={props.data.imageUrl}
+            src={props.data.mediumImageUrls[0].imageUrl}
           />
           <DialogContentText sx={itemNameStyle}>
             {props.data.itemName}

--- a/frontend/app/components/container/ItemCard/ItemCard.tsx
+++ b/frontend/app/components/container/ItemCard/ItemCard.tsx
@@ -74,7 +74,7 @@ export const ItemCard = ({ data }: { data: itemData }) => {
             <CardMedia
               component="img"
               height="250"
-              image={data.imageUrl}
+              image={data.mediumImageUrls[0].imageUrl}
               style={{ objectFit: "contain" }}
             />
           </Link>

--- a/frontend/app/components/container/ItemsCard/ItemsCard.hooks.ts
+++ b/frontend/app/components/container/ItemsCard/ItemsCard.hooks.ts
@@ -1,9 +1,9 @@
 import { apiClient } from "@/app/utils/baseApi";
-import { itemsData, itemData } from "@/app/type/types"
+import { itemsData, itemData } from "@/app/type/types";
 
 /**
  * 楽天の商品データを取得するapiを呼び出す
- * @description ローカル環境のモックapiから楽天の商品データを取得して返す
+ * @description DynamoDBから商品データを取得
  */
 export const useFetchItemsData = () => {
   const fetchItemsData = async (): Promise<itemData[]> => {

--- a/frontend/app/components/container/ItemsCard/ItemsCard.tsx
+++ b/frontend/app/components/container/ItemsCard/ItemsCard.tsx
@@ -12,7 +12,7 @@ export const ItemsCard = async () => {
 
   return (
     <>
-      <Container maxWidth="xl">
+      <Container maxWidth="xl" sx={{ marginBottom: 11 }}>
         <Title />
         <Grid container rowSpacing={2} columnSpacing={2}>
           {itemsData.map((data) => (

--- a/frontend/app/components/container/SearchResults/SearchResults.hooks.ts
+++ b/frontend/app/components/container/SearchResults/SearchResults.hooks.ts
@@ -2,7 +2,7 @@ import { itemData } from "@/app/type/types";
 import { apiClient } from "@/app/utils/baseApi";
 import { useRouter } from "next/navigation";
 
-export const usePutItem = () => {
+export const usePutItem = (handleClose: () => void) => {
   const router = useRouter();
 
   /**
@@ -31,6 +31,7 @@ export const usePutItem = () => {
           imageUrl: removeImageSizeParams(data.mediumImageUrls[0].imageUrl),
         }),
       );
+      handleClose();
       router.refresh();
     } catch (e) {
       console.log(e);

--- a/frontend/app/components/container/SearchResults/SearchResults.hooks.ts
+++ b/frontend/app/components/container/SearchResults/SearchResults.hooks.ts
@@ -1,0 +1,41 @@
+import { itemData } from "@/app/type/types";
+import { apiClient } from "@/app/utils/baseApi";
+import { useRouter } from "next/navigation";
+
+export const usePutItem = () => {
+  const router = useRouter();
+
+  /**
+   * 画像URLからサイズ指定のパラメータを削除して返す
+   * @param imageUrl 商品画像のURL
+   */
+  const removeImageSizeParams = (imageUrl: string): string => {
+    return imageUrl.split("?")[0];
+  };
+
+  /**
+   * 商品データ登録APIを実行
+   * @param data 楽天の商品データ
+   */
+  const putItemData = async (data: itemData): Promise<void> => {
+    try {
+      await apiClient(
+        "/api/put_item",
+        "POST",
+        "no-store",
+        JSON.stringify({
+          itemCode: data.itemCode,
+          itemName: data.itemName,
+          itemPrice: data.itemPrice.toString(),
+          itemUrl: data.itemUrl,
+          imageUrl: removeImageSizeParams(data.mediumImageUrls[0].imageUrl),
+        }),
+      );
+      router.refresh();
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+  return { removeImageSizeParams, putItemData };
+};

--- a/frontend/app/components/container/SearchResults/SearchResults.tsx
+++ b/frontend/app/components/container/SearchResults/SearchResults.tsx
@@ -7,6 +7,7 @@ import CardContent from "@mui/material/CardContent";
 import CardMedia from "@mui/material/CardMedia";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
+import AddIcon from "@mui/icons-material/Add";
 
 const itemNameStyle = {
   display: "-webkit-box",
@@ -31,7 +32,7 @@ export const SearchResults = ({ data }: { data: itemData }) => {
   };
 
   return (
-    <Grid item xs={12} sm={6} md={4} lg={3} xl={3}>
+    <Grid item xs={12} sm={6} md={4} lg={3}>
       <Card>
         <Link href={data.itemUrl} target="_blank">
           <CardMedia
@@ -51,7 +52,8 @@ export const SearchResults = ({ data }: { data: itemData }) => {
         </CardContent>
         <CardActions sx={{ justifyContent: "center" }}>
           <Button variant="contained" sx={{ fontWeight: 550 }}>
-            ほしいものリストに追加
+            <AddIcon fontSize="small" />
+            リストに追加
           </Button>
         </CardActions>
       </Card>

--- a/frontend/app/components/container/SearchResults/SearchResults.tsx
+++ b/frontend/app/components/container/SearchResults/SearchResults.tsx
@@ -20,8 +20,13 @@ const itemNameStyle = {
   marginBottom: "3%",
 };
 
-export const SearchResults = ({ data }: { data: itemData }) => {
-  const { putItemData, removeImageSizeParams } = usePutItem();
+type Props = {
+  data: itemData;
+  handleClose: () => void;
+};
+
+export const SearchResults = (props: Props) => {
+  const { putItemData, removeImageSizeParams } = usePutItem(props.handleClose);
 
   const formatPrice = (price: number): string => {
     return new Intl.NumberFormat("ja-JP", {
@@ -33,27 +38,33 @@ export const SearchResults = ({ data }: { data: itemData }) => {
   return (
     <Grid item xs={12} sm={6} md={4} lg={3}>
       <Card>
-        <Link href={data.itemUrl} target="_blank">
+        <Link href={props.data.itemUrl} target="_blank">
           <CardMedia
             component="img"
             height="200"
-            image={removeImageSizeParams(data.mediumImageUrls[0].imageUrl)}
+            image={removeImageSizeParams(
+              props.data.mediumImageUrls[0].imageUrl,
+            )}
             sx={{ objectFit: "contain" }}
           />
         </Link>
         <CardContent sx={{ paddingBottom: "2px" }}>
-          <Typography variant="body2" title={data.itemName} sx={itemNameStyle}>
-            {data.itemName}
+          <Typography
+            variant="body2"
+            title={props.data.itemName}
+            sx={itemNameStyle}
+          >
+            {props.data.itemName}
           </Typography>
           <Typography variant="body1" fontWeight="bold">
-            {formatPrice(data.itemPrice)}
+            {formatPrice(props.data.itemPrice)}
           </Typography>
         </CardContent>
         <CardActions sx={{ justifyContent: "center" }}>
           <Button
             variant="contained"
             sx={{ fontWeight: 550 }}
-            onClick={() => putItemData(data)}
+            onClick={() => putItemData(props.data)}
           >
             <AddIcon fontSize="small" />
             リストに追加

--- a/frontend/app/components/container/SearchResults/SearchResults.tsx
+++ b/frontend/app/components/container/SearchResults/SearchResults.tsx
@@ -1,4 +1,5 @@
 import { itemData } from "@/app/type/types";
+import { usePutItem } from "./SearchResults.hooks";
 import Link from "next/link";
 import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
@@ -20,9 +21,7 @@ const itemNameStyle = {
 };
 
 export const SearchResults = ({ data }: { data: itemData }) => {
-  const removeImageSizeParams = (url: string) => {
-    return url.split("?")[0];
-  };
+  const { putItemData, removeImageSizeParams } = usePutItem();
 
   const formatPrice = (price: number): string => {
     return new Intl.NumberFormat("ja-JP", {
@@ -51,7 +50,11 @@ export const SearchResults = ({ data }: { data: itemData }) => {
           </Typography>
         </CardContent>
         <CardActions sx={{ justifyContent: "center" }}>
-          <Button variant="contained" sx={{ fontWeight: 550 }}>
+          <Button
+            variant="contained"
+            sx={{ fontWeight: 550 }}
+            onClick={() => putItemData(data)}
+          >
             <AddIcon fontSize="small" />
             リストに追加
           </Button>

--- a/frontend/app/components/container/SearchResults/SearchResults.tsx
+++ b/frontend/app/components/container/SearchResults/SearchResults.tsx
@@ -1,0 +1,60 @@
+import { itemData } from "@/app/type/types";
+import Link from "next/link";
+import Button from "@mui/material/Button";
+import Card from "@mui/material/Card";
+import CardActions from "@mui/material/CardActions";
+import CardContent from "@mui/material/CardContent";
+import CardMedia from "@mui/material/CardMedia";
+import Grid from "@mui/material/Grid";
+import Typography from "@mui/material/Typography";
+
+const itemNameStyle = {
+  display: "-webkit-box",
+  WebkitBoxOrient: "vertical",
+  WebkitLineClamp: 3,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  height: 60,
+  marginBottom: "3%",
+};
+
+export const SearchResults = ({ data }: { data: itemData }) => {
+  const removeImageSizeParams = (url: string) => {
+    return url.split("?")[0];
+  };
+
+  const formatPrice = (price: number): string => {
+    return new Intl.NumberFormat("ja-JP", {
+      style: "currency",
+      currency: "JPY",
+    }).format(price);
+  };
+
+  return (
+    <Grid item xs={12} sm={6} md={4} lg={3} xl={3}>
+      <Card>
+        <Link href={data.itemUrl} target="_blank">
+          <CardMedia
+            component="img"
+            height="200"
+            image={removeImageSizeParams(data.mediumImageUrls[0].imageUrl)}
+            sx={{ objectFit: "contain" }}
+          />
+        </Link>
+        <CardContent sx={{ paddingBottom: "2px" }}>
+          <Typography variant="body2" title={data.itemName} sx={itemNameStyle}>
+            {data.itemName}
+          </Typography>
+          <Typography variant="body1" fontWeight="bold">
+            {formatPrice(data.itemPrice)}
+          </Typography>
+        </CardContent>
+        <CardActions sx={{ justifyContent: "center" }}>
+          <Button variant="contained" sx={{ fontWeight: 550 }}>
+            ほしいものリストに追加
+          </Button>
+        </CardActions>
+      </Card>
+    </Grid>
+  );
+};

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,3 +1,4 @@
+import { AddButton } from "./components/container/AddButton/AddButton";
 import { Header } from "./components/elements/Header/Header";
 import { ItemsCard } from "./components/container/ItemsCard/ItemsCard";
 
@@ -6,6 +7,7 @@ export default function Home() {
     <>
       <Header />
       <ItemsCard />
+      <AddButton />
     </>
   );
 }

--- a/frontend/app/type/types.ts
+++ b/frontend/app/type/types.ts
@@ -7,5 +7,5 @@ export type itemData = {
   itemName: string,
   itemPrice: number,
   itemUrl: string,
-  imageUrl: string,
-}
+  mediumImageUrls: { imageUrl: string }[],
+};


### PR DESCRIPTION
- フロントエンド
  - ホーム画面に追加ボタンを表示
  - 追加ボタンクリックで商品登録モーダルを表示
  - 商品名検索で楽天APIから商品データを取得
  - 取得結果を一覧で表示
  - リストに追加ボタンクリックで商品データをDynamoDBに登録

- バックエンド
  - 商品データをDynamoDBに登録するAPIを作成